### PR TITLE
fix: a partial keyframe survives the bake as a partial keyframe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,15 @@ jobs:
           python-version: '3.12'
 
       - name: Verify tag matches bl_info version
+        id: version
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           PKG=$(make -s info | awk '/^version:/ { print $2 }')
           echo "tag=$TAG  bl_info=$PKG"
           test "$TAG" = "$PKG"
+          # The zip is named from bl_info and carries no leading "v", so the
+          # notes cannot interpolate github.ref_name.
+          echo "version=$PKG" >> "$GITHUB_OUTPUT"
 
       - name: Build addon zip
         run: make zip
@@ -42,15 +46,15 @@ jobs:
           body: |
             **Install in Blender 5.0+:**
 
-            1. Download `proscenium-blender-${{ github.ref_name }}.zip` below
-            2. Edit → Preferences → Add-ons → Install…
+            1. Download `animatica-blender-${{ steps.version.outputs.version }}.zip` below
+            2. Edit → Preferences → Add-ons → Install from Disk…
             3. Pick the downloaded zip
-            4. Enable **Proscenium — AI Motion Generation**
+            4. Enable **Animatica — AI Motion Generation**
 
-            Sign in with your [Animatica](https://animatica.ai) account under **Preferences → Add-ons → Proscenium**.
+            Sign in with your [Animatica](https://animatica.ai) account under **Preferences → Add-ons → Animatica**.
 
-            **New to Proscenium?** Watch the [video tutorial playlist](https://www.youtube.com/watch?v=Wc349qOwjfM&list=PLAJ2UfUYhFQKZpFS8eh1eGUWJ0PAys1n1) on YouTube.
+            **New to Animatica?** Watch the [video tutorial playlist](https://www.youtube.com/watch?v=Wc349qOwjfM&list=PLAJ2UfUYhFQKZpFS8eh1eGUWJ0PAys1n1) on YouTube.
 
             **Need help?** Join the [Animatica Discord](https://discord.com/invite/A8CrURBewz).
 
-            Docs: [README](https://github.com/animatica-ai/proscenium-blender#readme) · [Using Proscenium](https://github.com/animatica-ai/proscenium-blender/blob/main/docs/usage.md)
+            Docs: [README](https://github.com/animatica-ai/animatica-blender-plugin#readme) · [Using Animatica](https://github.com/animatica-ai/animatica-blender-plugin/blob/main/docs/usage.md)

--- a/animatica_blender/constraints_ui.py
+++ b/animatica_blender/constraints_ui.py
@@ -105,16 +105,23 @@ def _iter_fcurve_collections(action):
                     yield cb.fcurves
 
 
-def strip_generated_keyframe_points(action) -> int:
+def strip_generated_keyframe_points(action, *, promote_unauthored: bool = False) -> int:
     """Remove ``GENERATED``-typed keyframe points from every F-curve on ``action``.
 
     Motion bakes tag constraint anchors as ``KEYFRAME`` and dense samples as
     ``GENERATED`` (see ``gltf_to_blender._tag_keyframe_types``). Reject should
     drop only the generated samples so keys added while previewing are kept.
-    When any channel has an authored key at a frame, generated samples on
-    other channels at that same frame are promoted to ``KEYFRAME`` too — that
-    preserves the full-body pose at the authored frame instead of leaving
-    unkeyed bones at rest.
+
+    ``promote_unauthored`` widens each authored FRAME to the whole body: generated
+    samples on every other channel at that frame become ``KEYFRAME`` too. That is
+    only right when this action is about to *become* the user's action and there is
+    nothing else holding the pose -- otherwise unkeyed bones would drop to rest.
+
+    It used to be unconditional, which undid partial keyframes: every caller here
+    merges the stripped preview back into the user's own action, so the promotion
+    turned a hips-only keyframe into a 77-bone one and the next generation pinned a
+    whole body at the rig's rest pose -- a T-pose. When there is a source action to
+    merge into, it already holds the user's authorship and nothing needs widening.
 
     Returns the number of keyframe points removed. F-curves left with no
     keys are removed.
@@ -127,7 +134,7 @@ def strip_generated_keyframe_points(action) -> int:
         for fc in iter_action_fcurves(action)
         for kp in fc.keyframe_points
         if kp.type != 'GENERATED'
-    }
+    } if promote_unauthored else set()
 
     removed = 0
     for fcurves in _iter_fcurve_collections(action):

--- a/animatica_blender/gltf_to_blender.py
+++ b/animatica_blender/gltf_to_blender.py
@@ -788,7 +788,11 @@ def bake_gltf_to_actions_per_block(
             _write_kps(_fc(data_path, 2), buf_f, buf_z)
 
         if anchor_frames is not None:
-            block_anchors = {f for f in anchor_frames if fs <= f <= fe}
+            block_anchors = (
+                {f: b for f, b in anchor_frames.items() if fs <= f <= fe}
+                if isinstance(anchor_frames, dict)
+                else {f for f in anchor_frames if fs <= f <= fe}
+            )
             _tag_keyframe_types(action, block_anchors)
 
         actions.append(action)
@@ -1619,17 +1623,46 @@ def _set_fcurve_keyframes(fcurves, data_path: str, axis: int, key_values: list[f
     fc.update()
 
 
-def _tag_keyframe_types(action: bpy.types.Action, anchor_frames: set[int]) -> None:
-    """Walk every fcurve on ``action`` and set each keyframe point's
-    ``type`` to ``'KEYFRAME'`` if its frame is in ``anchor_frames``, else
+def _tag_keyframe_types(
+    action: bpy.types.Action,
+    anchor_frames: "set[int] | dict[int, set[str]]",
+) -> None:
+    """Tag each keyframe point ``'KEYFRAME'`` where the user authored it, else
     ``'GENERATED'``. Makes the two kinds visually distinct in the dopesheet.
+
+    ``anchor_frames`` may be a plain set of frames -- every bone at those frames
+    counts as authored -- or a ``{frame: {bone, ...}}`` map, which is what a partial
+    keyframe needs.
+
+    This used to be frame-only, so a keyframe on one bone marked ALL of them as
+    authored at that frame: keying just the hips on a 77-bone rig produced 77 x 4 x 2
+    = 616 KEYFRAME points instead of 8. The next generation then read 77 user-edited
+    bones and widened the request back to a full-body pin -- the partial keyframe
+    survived the round trip as a complete one.
     """
-    anchors = {int(round(f)) for f in anchor_frames}
+    # Local import: constraints_ui <-> request_builder is circular at module load,
+    # and this module is pulled into that cycle (see _splice_fcurve below).
+    from .constraints_ui import _bone_name_from_data_path
+
+    if isinstance(anchor_frames, dict):
+        anchors: dict[int, set[str] | None] = {
+            int(round(f)): (set(b) if b is not None else None)
+            for f, b in anchor_frames.items()
+        }
+    else:
+        anchors = {int(round(f)): None for f in anchor_frames}
 
     def _tag(fcurves):
         for fc in fcurves:
+            bone = _bone_name_from_data_path(fc.data_path)
             for kp in fc.keyframe_points:
-                kp.type = 'KEYFRAME' if int(round(kp.co[0])) in anchors else 'GENERATED'
+                f = int(round(kp.co[0]))
+                if f in anchors:
+                    bones = anchors[f]
+                    authored = bones is None or (bone is not None and bone in bones)
+                else:
+                    authored = False
+                kp.type = 'KEYFRAME' if authored else 'GENERATED'
 
     flat = getattr(action, "fcurves", None)
     if flat is not None:

--- a/animatica_blender/operators.py
+++ b/animatica_blender/operators.py
@@ -619,14 +619,24 @@ class ANIMATICA_OT_generate(Operator):
         # (``Animatica_Pose`` / legacy ``Animatica_Poses``) is the user's
         # authored content (they chose to keep those poses as anchors), so
         # those keyframes should stay typed as ``KEYFRAME`` after the bake.
+        # Keep the BONE each key sits on, not just its frame. Tagging by frame
+        # alone marked every bone as authored wherever the user had keyed any one
+        # of them, so a hips-only keyframe came back from the bake looking like a
+        # full-body one and the next generation widened the request accordingly.
+        anchor_bones: dict[int, set[str]] = {}
         if src_action is not None and not _is_motion_bake_action(src_action):
             for fc in constraints_ui.iter_action_fcurves(src_action):
+                bone = constraints_ui._bone_name_from_data_path(fc.data_path)
                 for kp in fc.keyframe_points:
                     f = int(round(kp.co.x))
                     if gen_start <= f <= gen_end:
                         anchor_frames.add(f)
+                        if bone is not None:
+                            anchor_bones.setdefault(f, set()).add(bone)
 
-        self._anchor_frames = anchor_frames
+        # A dict iterates as its frames, so consumers that only want frames are
+        # unaffected; the tagger is the one that reads the bone sets.
+        self._anchor_frames = anchor_bones if anchor_bones else anchor_frames
 
         # Reset state and kick worker.
         settings.is_generating = True

--- a/animatica_blender/operators.py
+++ b/animatica_blender/operators.py
@@ -1041,7 +1041,13 @@ class ANIMATICA_OT_reject(Operator):
 
         n_rm = 0
         if is_motion_preview:
-            n_rm = constraints_ui.strip_generated_keyframe_points(preview)
+            # Widen authored frames to the whole body only when the preview is
+            # about to become the action outright; when ``source`` is restored it
+            # already carries the user's keys, and promoting here would merge the
+            # generated pose into them.
+            n_rm = constraints_ui.strip_generated_keyframe_points(
+                preview, promote_unauthored=(source is None),
+            )
             if source is not None:
                 constraints_ui.merge_preview_keyframes_into_source(source, preview)
                 arm.animation_data.action = source


### PR DESCRIPTION
Keying one bone marked every bone as authored, so a partial keyframe came back from the bake looking complete and the next generation widened the request to a full-body pin — which, at the rig's rest pose, is a T-pose.

## Cause

`_tag_keyframe_types` decided authorship by **frame**, not by (bone, frame):

```python
kp.type = 'KEYFRAME' if int(round(kp.co[0])) in anchors else 'GENERATED'
```

and `operators.py` threw the bone away when collecting anchors:

```python
for kp in fc.keyframe_points:
    f = int(round(kp.co.x))
    if gen_start <= f <= gen_end:
        anchor_frames.add(f)      # which bone? gone
```

On a 77-bone rig, two hips-only keys became 77 × 4 × 2 = **616** KEYFRAME points where the user had made 8. `_user_edited_bones_per_frame` then read 77 edited bones on the next generate.

## Fix

`anchor_frames` may now be `{frame: {bone, ...}}` as well as a plain `set[int]`. A dict iterates as its frames, so every consumer that only wants frames is unaffected — only the tagger reads the bone sets.

## Verified

Against a real 77-bone bake in Blender, two hips-only keys at frames 1 and 60:

| | KEYFRAME | GENERATED |
|---|---|---|
| before | 622 | 18038 |
| frame-only set (old behaviour) | 622 | 18038 |
| per-bone dict (new) | **14** | 18646 |

14 = hips rotation (4) + location (3), twice. `animatica:Hips` is the only bone tagged authored.

## Related

The server had the same widening in three independent places, all fixed in `motionmcp-ardy-cloud`: the constraint translation (`translate.py`), the retarget hop (`retarget_pipeline.py`), and the client-side motion corrector (`mmcp_server.py`). Measured end to end on the animatic rig, a hips-only keyframe went from flattening "a person jumps" to 0.7 cm of hip rise to producing 45.2 cm.

Two more things surfaced while chasing this, not fixed here — say if they're worth issues:

- Keys made in a generated action (`Animatica_Motion*`) are silently ignored as constraints, by design. Nothing tells the user, so a pose they authored just doesn't take effect.
- An empty prompt block builds an `unconditioned` segment with no warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Animation baking now preserves authored keyframes on a per-bone basis, improving the distinction between original and generated animation data.

- **Release Updates**
  - Blender releases are now branded as Animatica.
  - Download packages use version-based filenames.
  - Installation instructions now direct users to “Install from Disk…”.
  - Release documentation links have been updated to Animatica resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->